### PR TITLE
add --amend when docker manifest merge

### DIFF
--- a/.github/workflows/release_manually.yml
+++ b/.github/workflows/release_manually.yml
@@ -615,13 +615,7 @@ jobs:
           inputs: ${{ env.ONLINE_REGISTER }}/${{ inputs.job }}:${{ inputs.tag }}
           images: ${{ env.ONLINE_REGISTER }}/community-operator:${{ inputs.tag }}-amd64,${{ env.ONLINE_REGISTER }}/community-operator:${{ inputs.tag }}-arm64
           push: true
-
-      - name: Create and push manifest images sidecar(used for initconf, sidecar, batchjob/backup)
-        uses: Noelware/docker-manifest-action@master
-        with:
-          inputs: ${{ env.ONLINE_REGISTER }}/${{ inputs.job }}:${{ inputs.tag }}
-          images: ${{ env.ONLINE_REGISTER }}/community-operator:${{ inputs.tag }}-amd64,${{ env.ONLINE_REGISTER }}/community-operator:${{ inputs.tag }}-arm64
-          push: true
+          amend: true
 
   pgbouncer:
     if: ${{ inputs.job == 'pgbouncer' }}


### PR DESCRIPTION
closes/fixes repeated create manifest failed, add --amend option

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
