### PR TITLE
更改metrics-exporter容器连接数据库的账户

### DIFF
--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -306,8 +306,13 @@ func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 	sctOpName := s.cluster.GetNameForResource(mysqlcluster.Secret)
 	switch name {
 	case containerExporterName:
-		env = append(env, s.envVarFromSecret(sctOpName, "USER", "METRICS_EXPORTER_USER", false))
-		env = append(env, s.envVarFromSecret(sctOpName, "PASSWORD", "METRICS_EXPORTER_PASSWORD", false))
+		// 把metrics-exporter容器连接mysql的账户从sys_exporter切换到root, sys_exporter的权限控制被写死在sidecar的代码里了
+		// 如何重新打包sidecar已不可考
+		env = append(env, core.EnvVar{
+			Name:  "USER",
+			Value: "root",
+		})
+		env = append(env, s.envVarFromSecret(sctName, "PASSWORD", "ROOT_PASSWORD", false))
 		env = append(env, core.EnvVar{
 			Name:  "DATA_SOURCE_NAME",
 			Value: fmt.Sprintf("$(USER):$(PASSWORD)@(127.0.0.1:%d)/", s.cluster.ExporterDataSourcePort()),

--- a/pkg/sidecar/appconf.go
+++ b/pkg/sidecar/appconf.go
@@ -194,6 +194,9 @@ func initFileQuery(cfg *Config, gtidPurged string) []byte {
 
 	// configure metrics exporter user
 	queries = append(queries, createUserQuery(cfg.MetricsUser, cfg.MetricsPassword, "127.0.0.1",
+		// sys_exporter的权限在这里写死了, 如果需要增加权限就像下面这样一行, 增加后需要重新打包sidecar,
+		// 这里会生成sql语句写入到operator-init.sql
+		//[]string{"SELECT", "PROCESS", "REPLICATION CLIENT", "REPLICATION SLAVE"}, "*.*",
 		[]string{"SELECT", "PROCESS", "REPLICATION CLIENT"}, "*.*",
 		[]string{"SELECT", "CREATE"}, fmt.Sprintf("%s.%s", toolsDbName, toolsHeartbeatTableName))...)
 


### PR DESCRIPTION
把metrics-exporter容器连接mysql的账户从sys_exporter切换到root, sys_exporter的权限控制被写死在sidecar的代码里了
- 避免麻烦的打包sidecar
- 避免以后增加指标重新设定权限