### PR TITLE
fix: go mod tidy failed

### DIFF
--- a/arm64/images/mysql-operator/Dockerfile
+++ b/arm64/images/mysql-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 AS builder
+FROM golang:1.21 AS builder
 
 USER root
 
@@ -13,7 +13,6 @@ WORKDIR /build
 RUN wget -O arm64.zip https://github.com/ksmartdata/mysql-operator/archive/refs/heads/extra_image.zip
 RUN unzip arm64.zip
 WORKDIR /build/mysql-operator-extra_image
-RUN go mod tidy
 RUN CGO_ENABLED=0 go build  -o /mysql-operator  cmd/mysql-operator/main.go
 
 


### PR DESCRIPTION
修复流水线(https://github.com/ksmartdata/mysql-operator/actions/runs/19418387896/job/55551103627) 的如下错误:
```
> [linux/amd64 builder 7/8] RUN go mod tidy	:
0.066 go: go.mod file indicates go 1.21, but maximum version supported by tidy is 1.19
------
Dockerfile:16
--------------------
  14 |     RUN unzip arm64.zip
  15 |     WORKDIR /build/mysql-operator-extra_image
  16 | >>> RUN go mod tidy
  17 |     RUN CGO_ENABLED=0 go build  -o /mysql-operator  cmd/mysql-operator/main.go
  18 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod tidy" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c go mod tidy" did not complete successfully: exit code: 1
```